### PR TITLE
Fix build when compiler passes -Wl,--as-needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ LDFLAGS += -ludev
 LDFLAGS += -lxwiimote
 
 wiimote-pad: wiimote-pad.c
+	$(CC) -o $@ $^ $(LDFLAGS) $(CFLAGS) $(CPPFLAGS)
 
 clean:
 	@rm -rf wiimote-pad


### PR DESCRIPTION
Hello,

Nowadays, GCC in Ubuntu (and presumaly Debian) passes the `-Wl,--as-needed` option to the linker.

This essentially makes the linker skip the libraries mentioned in the command line if they are mentioned before anything that needs them.

When building in Ubuntu, GNU make runs the following command:

```bash
  cc -std=c99 -D_BSD_SOURCE -D_DEFAULT_SOURCE -Wall -Wextra \
     -I../xwiimote/lib \
     -L../xwiimote/.libs -ludev -lxwiimote \
     wiimote-pad.c   -o wiimote-pad
```
.. where `wiimote-pad.c` (the source file that requires libxwiimote) is mentioned _after_ `-lxwiimote`.

This makes the build fail with linker errors:

```make
  cc -std=c99 -D_BSD_SOURCE -D_DEFAULT_SOURCE -Wall -Wextra -I../xwiimote/lib -L../xwiimote/.libs -ludev -lxwiimote  wiimote-pad.c   -o wiimote-pad
  /usr/bin/ld: /tmp/ccdQHmlV.o: in function `wiimote_refresh':
  wiimote-pad.c:(.text+0x9a8): undefined reference to `xwii_iface_open'
  /usr/bin/ld: /tmp/ccdQHmlV.o: in function `wiimote_poll':
  wiimote-pad.c:(.text+0xce5): undefined reference to `xwii_iface_dispatch'
  /usr/bin/ld: /tmp/ccdQHmlV.o: in function `dev_create':
  wiimote-pad.c:(.text+0xe4f): undefined reference to `udev_new'
  /usr/bin/ld: wiimote-pad.c:(.text+0xead): undefined reference to `udev_device_new_from_devnum'
  /usr/bin/ld: wiimote-pad.c:(.text+0xf11): undefined reference to `udev_device_get_parent_with_subsystem_devtype'
  /usr/bin/ld: wiimote-pad.c:(.text+0xf66): undefined reference to `udev_device_get_driver'
  /usr/bin/ld: wiimote-pad.c:(.text+0xf7c): undefined reference to `udev_device_get_subsystem'
  /usr/bin/ld: wiimote-pad.c:(.text+0x1015): undefined reference to `udev_device_get_syspath'
  /usr/bin/ld: wiimote-pad.c:(.text+0x102b): undefined reference to `udev_device_get_sysname'
  /usr/bin/ld: wiimote-pad.c:(.text+0x11e1): undefined reference to `xwii_iface_new'
  /usr/bin/ld: wiimote-pad.c:(.text+0x1247): undefined reference to `xwii_iface_open'
  /usr/bin/ld: wiimote-pad.c:(.text+0x129b): undefined reference to `xwii_iface_opened'
  /usr/bin/ld: wiimote-pad.c:(.text+0x12f3): undefined reference to `xwii_iface_get_fd'
  /usr/bin/ld: wiimote-pad.c:(.text+0x1333): undefined reference to `udev_device_unref'
  /usr/bin/ld: wiimote-pad.c:(.text+0x1342): undefined reference to `udev_unref'
  /usr/bin/ld: /tmp/ccdQHmlV.o: in function `dev_destroy':
  wiimote-pad.c:(.text+0x13c9): undefined reference to `xwii_iface_unref'
  collect2: error: ld returned 1 exit status
  make: *** [<builtin>: wiimote-pad] Error 1
```

Although adding the `-Wl,--no-as-needed` option as the first `LDFLAGS` option would fix the issue, adding an explicit make rule seems to be cleaner.

Thanks,
Olivier